### PR TITLE
Add toprank to GEO toolkits

### DIFF
--- a/data/repos/geo-toolkits.yaml
+++ b/data/repos/geo-toolkits.yaml
@@ -79,3 +79,13 @@
   language: Go
   type: tool
   maintained: true
+
+- name: toprank
+  repo: nowork-studio/toprank
+  url: https://github.com/nowork-studio/toprank
+  category: geo-toolkits
+  description: Claude Code plugin for SEO and Google Ads — Search Console analysis, content writing, CMS setup, and AI-search-ready optimization workflows.
+  stars: 115
+  language: Markdown
+  type: skill
+  maintained: true


### PR DESCRIPTION
## Summary
- add `nowork-studio/toprank` to `data/repos/geo-toolkits.yaml`
- classify it as a maintained Claude Code skill/plugin for SEO and AI-search workflows

## Why it fits
Toprank is an open-source Claude Code plugin for SEO and Google Ads with Search Console analysis, content writing, CMS setup, and AI-search-ready optimization workflows, which fits the GEO toolkit / skills category.